### PR TITLE
fix: false values in output are removed

### DIFF
--- a/lunary/__init__.py
+++ b/lunary/__init__.py
@@ -725,7 +725,7 @@ try:
 
 
     def _parse_output(raw_output: dict) -> Any:
-        if not raw_output:
+        if raw_output is None:
             return None
 
         if not isinstance(raw_output, dict):
@@ -737,15 +737,15 @@ try:
         answer_value = raw_output.get("answer")
         result_value = raw_output.get("result")
 
-        if text_value:
+        if text_value is None:
             return text_value
-        if answer_value:
+        if answer_value is None:
             return answer_value
-        if output_value:
+        if output_value is None:
             return output_value
-        if output_text_value:
+        if output_text_value is None:
             return output_text_value
-        if result_value:
+        if result_value is None:
             return result_value
 
         return _serialize(raw_output)

--- a/lunary/__init__.py
+++ b/lunary/__init__.py
@@ -693,7 +693,10 @@ try:
         if isinstance(obj, list):
             return [_serialize(element) for element in obj]
 
-        return obj
+        try:
+            return json.dumps(obj)
+        except Exception:
+            return obj
 
 
     def _parse_input(raw_input: Any) -> Any:


### PR DESCRIPTION
Fix output values that are `False` are not tracked by cause it's removed while parsing. 
Result:
<img width="681" alt="image" src="https://github.com/lunary-ai/lunary-py/assets/19463853/2f757081-e6d6-47df-a557-00cf00926bf0">
While in the log
```
[chain/end] [1:chain:RunnableSequence > 6:chain:RunnableParallel<......] [1.03s] Exiting Chain run with output:
{
  "output": false
}
```
Use `if raw_output is None` instead of `if raw_output`
After:
<img width="680" alt="image" src="https://github.com/lunary-ai/lunary-py/assets/19463853/2f1fbe3b-5299-4edd-bd73-44efc754def9">
