### PR TITLE
Add ability to pass user id and props into threads

### DIFF
--- a/lunary/thread.py
+++ b/lunary/thread.py
@@ -11,16 +11,27 @@ class Message(TypedDict, total=False):
 
 
 class Thread:
-    def __init__(self, track_event, id: Optional[str] = None, tags: Optional[List[str]] = None):
+    def __init__(
+        self, 
+        track_event, 
+        user_id: Optional[str] = None, 
+        user_props: Optional[dict] = None,
+        id: Optional[str] = None, 
+        tags: Optional[List[str]] = None
+    ):
         self.id = id or str(uuid.uuid4())
+        self.user_id = user_id
+        self.user_props = user_props
         self.tags = tags
         self.track_event = track_event
 
-    def track_message(self, message: Message, feedback=None) -> str:
+    def track_message(self, message: Message, user_id=None, user_props=None, feedback=None) -> str:
         run_id = message.get("id", str(uuid.uuid4()))
 
         self.track_event("thread", "chat",
                          run_id=run_id,
+                         user_id=self.user_id,
+                         user_props=self.user_props,
                          parent_run_id=self.id,
                          thread_tags=self.tags,
                          feedback=feedback,


### PR DESCRIPTION
This makes sense in some cases where we are already opening threads and have access to the user ID. Mainly makes the code more readable