### PR TITLE
feat: Add agent event if agentName in metadata

### DIFF
--- a/lunary/__init__.py
+++ b/lunary/__init__.py
@@ -1004,6 +1004,25 @@ try:
                 params = filter_params(params)
                 input = _parse_input(prompts)
 
+                agentName = metadata.get("agentName")
+
+                if agentName is not None:
+                    self.__track_event(
+                        "agent",
+                        "start",
+                        user_id=user_id,
+                        run_id=run_id_str,
+                        parent_run_id=parent_run_id,
+                        name=name,
+                        input=input,
+                        tags=tags,
+                        metadata=metadata,
+                        params=params,
+                        user_props=user_props,
+                        app_id=self.__app_id,
+                        callback_queue=self.queue
+                    )
+
                 self.__track_event(
                     "llm",
                     "start",


### PR DESCRIPTION
In our implementation where we orchestrate agents with LangGraph and stream chunks async, there is no place where it makes sense to add an `Agent` decorator, mostly because we are streaming the chunks async. 

It makes more sense to pass the agent name in the metadata when the tools are bound to an agent so that each invocation contains the metadata, i.e.

```
model_with_tools = self._model.bind_tools(self._tools).with_config(RunnableConfig(metadata={"agentName": self._agent_name}))
``` 

but this means the metadata is only available `on_chat_model_start`. So here I added a check to see if that metadata is present, and add an additional event to denote that an agent started an action