### PR TITLE
Retreive name from kwargs in LunaryCallbackHandler.on_retriever_start

### DIFF
--- a/lunary/__init__.py
+++ b/lunary/__init__.py
@@ -1402,6 +1402,7 @@ try:
             query: str,
             run_id: Optional[UUID] = None,
             parent_run_id: Optional[UUID] = None,
+            name: Union[str, None] = None,
             **kwargs: Any,
         ) -> None:
             try:
@@ -1412,7 +1413,8 @@ try:
                 user_id = _get_user_id(kwargs.get("metadata"))
                 user_props = _get_user_props(kwargs.get("metadata"))
 
-                name = serialized.get("name")
+                if name is None and serialized:
+                    name = serialized.get("name")
 
                 self.__track_event(
                     "retriever",


### PR DESCRIPTION
fix: handle missing `name` in `on_retriever_start`

Resolved the error:
`ERROR:lunary:An error occurred in 'on_retriever_start': 'NoneType' object has no attribute 'get'`.

The issue occurred because `langchain_core` sends `name` in `callback_manager.on_retriever_start`, and serialized as None

Fix implemented by adding the `name` parameter to `on_retriever_start`